### PR TITLE
Make Hermes run on a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,6 @@ COPY . /hermes
 
 RUN pip install -r requirements.txt
 
+EXPOSE 8000
+
 CMD ["./run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,6 @@ RUN pip install -r requirements.txt
 
 EXPOSE 8000
 
+RUN chmod +x ./run.sh
+
 CMD ["./run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,7 @@ COPY . /hermes
 
 RUN pip install -r requirements.txt
 
+# Run startup.py if database is not set
+RUN test -e hermes.db && python startup.py
+
 CMD ["uvicorn", "main:app", "--reload"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.12
+
+WORKDIR /hermes
+
+COPY . /hermes
+
+RUN pip install -r requirements.txt
+
+CMD ["uvicorn", "main:app", "--reload"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,4 @@ COPY . /hermes
 
 RUN pip install -r requirements.txt
 
-# Run startup.py if database is not set
-RUN test -e hermes.db && python startup.py
-
-CMD ["uvicorn", "main:app", "--reload"]
+CMD ["./run.sh"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Hermes is a FastAPI powered employee management web application. It allows you t
 - Generate reports on employee data
 - Create test admin account with unique employee checks and confirmation boxes
 - Automated Slack and E-mail triggers with employee onboarding, updating or offboarding
-- Security notification for access to privilages data
+- Security notification for access to privileges data
 - API call for generating active employee lists
 - Customise Hermes with your company's logo and color scheme
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ you need to link a directory from your host system to the container.
 
 1. Clone the repository: `git clone https://github.com/DarthTigerson/Hermes.git`
 2. Build the image from the Dockerfile `docker build --tag <YOUR_TAG> .`
-3. Create and run a container from the image `docker run -v <DB_FOLDER>:/hermes/db -p 8000:8000 <YOUR_TAG>`
+3. Create and run a container from the image: `docker run --mount type=bind,source=<DB_FILE_PATH>,target=/hermes/db -p 8000:8000 <YOUR_TAG>`
 
 ## Run prebuilt image
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ This project creates a local database on your system.
 6. To assign a role to an employee, go to the employee details page and select a role from the dropdown menu. Click "Save" to assign the role.
 7. To create a test admin account, click the "Create Test Admin" button and follow the prompts.
 
-**Note:** On the first run, you need to create an admin user by running the `startup.py` script. Uncomment the bottom lines of the file and run it with `python startup.py`. The default username and password for the admin user is `hermes` and `hermes`, respectively.
+**Note:** On the first run, you need to create an admin user by running the `startup.py` script.  
+Uncomment the bottom lines of the file and run it with `python startup.py`.  
+The default username and password for the admin user is `hermes` and `hermes`, respectively.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Hermes v1.5.0
 
-Hermes is a FastAPI powered employee management web application. It allows you to manage your employees, their roles, and their onboarding/offboarding status.
+Hermes is a FastAPI powered employee management web application.  
+It allows you to manage your employees, their roles, and their onboarding/offboarding status.
 ![Capture of Hermes](/static/img/capture.gif)
 
 ## Features
@@ -30,8 +31,9 @@ You can install the [project locally](#local-installation), and run it on your o
 
 ## Run docker image
 
-It is possible to build your own docker image from the `Dockerfile` in this repository.
-Although, the preferred way to do it is to pull a [prebuilt image](#run-prebuilt-image). 
+It is possible to build your own docker image from the `Dockerfile` in this repository.  
+Although, the preferred way to do it is to pull a [prebuilt image](#run-prebuilt-image).   
+This project creates a local database on your system.
 
 1. Clone the repository: `git clone https://github.com/DarthTigerson/Hermes.git`
 2. Build the image from the Dockerfile `docker build --tag <YOUR_TAG> .`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Hermes is a FastAPI powered employee management web application. It allows you t
 
 # Installation
 
-You can install the [project locally](#local-installation), and run it on your own machine, or you could run it in a [docker container](#build-and-run-docker-image-locally).
+You can install the [project locally](#local-installation), and run it on your own machine, or you could run it in a [docker container](#local-installation).
 
 ## Local installation
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Hermes is a FastAPI powered employee management web application. It allows you t
 
 # Installation
 
-You can install the [project locally](#local-installation), and run it on your own machine, or you could run it in a [docker container](#local-installation).
+You can install the [project locally](#local-installation), and run it on your own machine, or you could run it in a [docker container](#run-docker-image).
 
 ## Local installation
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,30 @@ Hermes is a FastAPI powered employee management web application. It allows you t
 - API call for generating active employee lists
 - Customise Hermes with your company's logo and color scheme
 
-## Installation
+# Installation
+
+You can install the [project locally](#local-installation), and run it on your own machine, or you could run it in a [docker container](#build-and-run-docker-image-locally).
+
+## Local installation
 
 1. Clone the repository: `git clone https://github.com/DarthTigerson/Hermes.git`
 2. Install the dependencies: `pip install -r requirements.txt`
 3. Create a `.env` file and set the environment variables (see `.env.example` for an example)
 4. Run the application: `uvicorn main:app --reload`
+
+## Run docker image
+
+It is possible to build your own docker image from the `Dockerfile` in this repository.
+Although, the preferred way to do it is to pull a [prebuilt image](#run-prebuilt-image). 
+
+1. Clone the repository: `git clone https://github.com/DarthTigerson/Hermes.git`
+2. Build the image from the Dockerfile `docker build --tag <YOUR_TAG> .`
+3. Create and run a container from the image `docker run -p 8000:8000 <YOUR_TAG>`
+
+## Run prebuilt image
+
+1. Pull the image from Dockerhub: TODO
+2. Run the docker image and set the forwarding web port: `docker run -d -p <YOUR_PORT>:8000 <DOCKER_IMAGE>`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -33,16 +33,18 @@ You can install the [project locally](#local-installation), and run it on your o
 
 It is possible to build your own docker image from the `Dockerfile` in this repository.  
 Although, the preferred way to do it is to pull a [prebuilt image](#run-prebuilt-image).   
-This project creates a local database on your system.
+This project creates a local database on your system. So in order to use this in a container,
+you need to link a directory from your host system to the container.
+
 
 1. Clone the repository: `git clone https://github.com/DarthTigerson/Hermes.git`
 2. Build the image from the Dockerfile `docker build --tag <YOUR_TAG> .`
-3. Create and run a container from the image `docker run -p 8000:8000 <YOUR_TAG>`
+3. Create and run a container from the image `docker run -v <DB_FOLDER>:/hermes/db -p 8000:8000 <YOUR_TAG>`
 
 ## Run prebuilt image
 
 1. Pull the image from Dockerhub: TODO
-2. Run the docker image and set the forwarding web port: `docker run -d -p <YOUR_PORT>:8000 <DOCKER_IMAGE>`
+2. Run the docker image and set the forwarding web port: `docker run -d -v <DB_FOLDER>:/hermes/db -p <YOUR_PORT>:8000 <DOCKER_IMAGE>`
 
 ## Usage
 

--- a/alembic.ini
+++ b/alembic.ini
@@ -60,7 +60,7 @@ version_path_separator = os  # Use os.pathsep. Default configuration used for ne
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = sqlite://db/hermes.db
+sqlalchemy.url = sqlite://./db/hermes.db
 
 
 [post_write_hooks]

--- a/alembic.ini
+++ b/alembic.ini
@@ -60,7 +60,7 @@ version_path_separator = os  # Use os.pathsep. Default configuration used for ne
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = sqlite:///hermes.db
+sqlalchemy.url = sqlite://db/hermes.db
 
 
 [post_write_hooks]

--- a/database.py
+++ b/database.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 
 
-SQLALCHEMY_DATABASE_URL = 'sqlite:///db/hermes.db'
+SQLALCHEMY_DATABASE_URL = 'sqlite:///./db/hermes.db'
 engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={'check_same_thread': False})
 SessionLocal = sessionmaker(autocommit=False,autoflush=False,bind=engine)
 Base = declarative_base()

--- a/database.py
+++ b/database.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 
 
-SQLALCHEMY_DATABASE_URL = 'sqlite:///./hermes.db'
+SQLALCHEMY_DATABASE_URL = 'sqlite:///db/hermes.db'
 engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={'check_same_thread': False})
 SessionLocal = sessionmaker(autocommit=False,autoflush=False,bind=engine)
 Base = declarative_base()

--- a/run.sh
+++ b/run.sh
@@ -6,4 +6,4 @@ then
   python startup.py --overwrite
 fi
 
-uvicorn main:app --reload
+uvicorn main:app --host 0.0.0.0 --reload

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ ! -d db ]
+if [ ! -e db/hermes.db ]
 then
   mkdir db
   python startup.py --overwrite

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-test -e hermes.db && python startup.py
+if [ ! -d db ]
+then
+  mkdir db
+  python startup.py --overwrite
+fi
 
 uvicorn main:app --reload

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+test -e hermes.db && python startup.py
+
+uvicorn main:app --reload

--- a/startup.py
+++ b/startup.py
@@ -1,6 +1,7 @@
 from database import SessionLocal, engine
 import models, os, base64
 from routers import admin
+import sys
 
 def create_default_user():
     db = SessionLocal()
@@ -191,12 +192,15 @@ def create_settings_table():
 def full_run():
     os.system('cls' if os.name == 'nt' else 'clear')
 
-    db_path = "./db/hermes.db"
-    if os.path.exists(db_path):
-        db_run_status = input("You are about to overwrite Hermes database!\nThis will delete all records and accounts currently present.\n\nAre you sure you want to proceed? (y/n): ")
-    else:
-        print("Setting up database for the first time.")
+    if len(sys.argv) > 1 and sys.argv[1] == "--overwrite":
         db_run_status = "y"
+    else:
+        db_path = "./db/hermes.db"
+        if os.path.exists(db_path):
+            db_run_status = input("You are about to overwrite Hermes database!\nThis will delete all records and accounts currently present.\n\nAre you sure you want to proceed? (y/n): ")
+        else:
+            print("Setting up database for the first time.")
+            db_run_status = "y"
 
 
     if db_run_status.lower() == 'y':

--- a/startup.py
+++ b/startup.py
@@ -191,7 +191,7 @@ def create_settings_table():
 def full_run():
     os.system('cls' if os.name == 'nt' else 'clear')
 
-    db_path = "db/hermes.db"
+    db_path = "./db/hermes.db"
     if os.path.exists(db_path):
         db_run_status = input("You are about to overwrite Hermes database!\nThis will delete all records and accounts currently present.\n\nAre you sure you want to proceed? (y/n): ")
     else:

--- a/startup.py
+++ b/startup.py
@@ -191,7 +191,7 @@ def create_settings_table():
 def full_run():
     os.system('cls' if os.name == 'nt' else 'clear')
 
-    db_path = "hermes.db"
+    db_path = "db/hermes.db"
     if os.path.exists(db_path):
         db_run_status = input("You are about to overwrite Hermes database!\nThis will delete all records and accounts currently present.\n\nAre you sure you want to proceed? (y/n): ")
     else:


### PR DESCRIPTION
[Issue](https://github.com/DarthTigerson/Hermes/issues/52)
[Hermes dev instance](http://sshermes.ddns.net).

Several changes were made in order to allow Hermes to run in a container, and make the database persistent across multiple instances of the container.

### Moved database file path.

To allow a persistent database across multiple instances of the container, the file should be saved to the host system. 
This was accomplished by linking a directory from the host system to the container system.
The host linked directory should be empty before the first run of the container in order to work.
The new path of the database from the project root is: `db/hermes.db`.

### Added overwrite mode to the startup.py script

The python script `startup.py` now accepts the argument `--overwrite`.
If this argument is present, the script re-initializes the database, and overwrites all previously stored information.

### Created a script to run the project

The script `run.sh` checks if the database is already initialized. If not, runs the script `startup.py` on overwrite mode.
This allows for an easy way to run the system with no information, by moving (or deleting) the `hermes.db` file on the host system.
At last, the script `run.sh` launches **uvicorn** to host on `0.0.0.0`.

### Created a Dockerfile to make an image of the project

This Dockerfile copies all the files from the project to the image, installs the requirements, and has an optional step to run `run.sh`.
This final step may be overridden by running the container with an entrypoint.
The arguments `-ti --entrypoint=/bin/bash` may be used to enter the container for debugging purposes.

### Updated README.md

Provisional instructions were added to show how to build a docker image from the project.