### PR TITLE
Correction on logo easter egg

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -455,6 +455,8 @@
         if (clickCount === 5) {
             clickCount = 0; // reset the count
             logo.classList.add('animate-logo');
+        } else {
+          logo.classList.remove('animate-logo');
         }
     });
 </script>


### PR DESCRIPTION
Currently, the logo easter egg only works one time, no matter how many times you click the logo.
With this correction, the css animated class gets removed and reassigned every 5 clicks.