### PR TITLE
Improvements on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ You can install the [project locally](#local-installation), and run it on your o
 1. Clone the repository: `git clone https://github.com/DarthTigerson/Hermes.git`
 2. Install the dependencies: `pip install -r requirements.txt`
 3. Create a `.env` file and set the environment variables (see `.env.example` for an example)
-4. Run the application: `uvicorn main:app --reload`
+4. Give executable permissions to the launcher script: `chmod +x run.sh`
+5. Run the application: `./run.sh`
 
 ## Build Docker image
 
@@ -38,14 +39,24 @@ you need to link an empty directory from your host system to the container.
 
 1. Clone the repository: `git clone https://github.com/DarthTigerson/Hermes.git`
 2. Build the image from the Dockerfile `docker build --tag <YOUR_TAG> .`
-3. Create and run a container from the image: `docker run --mount type=bind,source=<DB_FILE_PATH>,target=/hermes/db -p 8000:8000 <YOUR_TAG>`
+3. Create and run a container from the image:  
+`docker run --mount type=bind,source=<DB_FILE_PATH>,target=/hermes/db -p 8000:8000 <YOUR_TAG>`  
+
+[Learn more](https://docs.docker.com/engine/reference/commandline/run/) on running docker containers.
 
 ## Run prebuilt image
 
 1. Pull the image from Dockerhub: `docker pull w3edd/hermes:latest`
-2. Run the docker image and set the forwarding web port: `docker run -d -v <DB_FOLDER>:/hermes/db -p <YOUR_PORT>:8000 w3edd/hermes:latest`
+2. Run the docker image and set the forwarding web port:  
+`docker run --mount type=bind,source=<DB_FILE_PATH>,target=/hermes/db -p 8000:8000 w3edd/hermes:latest`  
+
+[Learn more](https://docs.docker.com/engine/reference/commandline/run/) on running docker containers.
 
 ## Usage
+
+> [!NOTE]  
+> When not running on a container, on the first run, you need to create an admin user by running the `python startup.py` script.    
+> The default username and password for the admin user is `hermes` and `hermes`, respectively.
 
 1. Open your web browser and go to `http://localhost:8000`
 2. Use the navigation menu to access the different features of the application
@@ -54,9 +65,6 @@ you need to link an empty directory from your host system to the container.
 5. To delete an employee, go to the employee details page and click the "Delete" button. Confirm the deletion when prompted.
 6. To assign a role to an employee, go to the employee details page and select a role from the dropdown menu. Click "Save" to assign the role.
 7. To create a test admin account, click the "Create Test Admin" button and follow the prompts.
-
-**Note:** When not running on a container, on the first run, you need to create an admin user by running the `python startup.py` script.  
-The default username and password for the admin user is `hermes` and `hermes`, respectively.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Hermes is a FastAPI powered employee management web application.  
 It allows you to manage your employees, their roles, and their onboarding/offboarding status.
-![Capture of Hermes](/static/img/capture.gif)
+![Capture of Hermes](static/img/capture.gif)
 
 ## Features
 
@@ -20,7 +20,7 @@ It allows you to manage your employees, their roles, and their onboarding/offboa
 
 # Installation
 
-You can install the [project locally](#local-installation), and run it on your own machine, or you could run it in a [docker container](#run-docker-image).
+You can install the [project locally](#local-installation), and run it as you see fit, or you could run it in a [docker container](#run-docker-image).
 
 ## Local installation
 
@@ -55,16 +55,22 @@ you need to link an empty directory from your host system to the container.
 ## Usage
 
 > [!NOTE]  
-> When not running on a container, on the first run, you need to create an admin user by running the `python startup.py` script.    
-> The default username and password for the admin user is `hermes` and `hermes`, respectively.
+> If running manually, on the first run, you need to set the database by running the `python startup.py` script.  
+> The default username and password for the admin user are `hermes` and `hermes`, respectively.
 
-1. Open your web browser and go to `http://localhost:8000`
-2. Use the navigation menu to access the different features of the application
-3. To add a new employee, click the "Add Employee" button and fill out the form. Click "Save" to add the employee.
-4. To edit an existing employee, go to the employee details page and click the "Edit" button. Make the necessary changes and click "Save" to update the employee.
-5. To delete an employee, go to the employee details page and click the "Delete" button. Confirm the deletion when prompted.
-6. To assign a role to an employee, go to the employee details page and select a role from the dropdown menu. Click "Save" to assign the role.
-7. To create a test admin account, click the "Create Test Admin" button and follow the prompts.
+1. To start the server, execute the `run.sh` script. You can optionally, run `uvicorn` manually instead: `uvicorn main:app --reload`
+2. Open your web browser and go to `http://localhost:8000`
+3. Use the navigation menu to access the different features of the application
+4. To add a new employee, click the "Add Employee" button and fill out the form. Click "Save" to add the employee.
+5. To edit an existing employee, go to the employee details page and click the "Edit" button. Make the necessary changes and click "Save" to update the employee.
+6. To delete an employee, go to the employee details page and click the "Delete" button. Confirm the deletion when prompted.
+7. To assign a role to an employee, go to the employee details page and select a role from the dropdown menu. Click "Save" to assign the role.
+8. To create a test admin account, click the "Create Test Admin" button and follow the prompts.
+
+> [!NOTE]
+> When running `uvicorn` manually, you need to set the ip address and port where the service will be running.  
+> For example: `uvicorn main:app --reload --host 0.0.0.0 --port 8000`  
+> To make the service available for your network, you have to set the host to `0.0.0.0`
 
 ## Contributing
 


### PR DESCRIPTION
### Header README.md image corrected.

An absolute path was being used, instead of a relative path as indicated in the Github Markdown [documentation](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).

From `![Capture of Hermes](/static/img/capture.gif)`
to `![Capture of Hermes](static/img/capture.gif)`

### Links to Docker documentation

Links to the Docker documentation on how to run a container were added after the instructions on how to run Hermes from a container.

### Improving notes

The existing note about running the `startup.py` script was improved, so it can be shown as a proper note on the Github repository homepage.  

A note on how to run the project manually with **uvicorn** was added, explaining how to set the service host and port, and how to make the service available for the network.

### Stating preferred way to run the service

Previously, the instructions only explained how to run the service manually with **uvicorn**.  
Now, the instructions clearly explain the preferred way to start the service with the `run.sh` script, as this will be easier for the sys admin.
