### PR TITLE
Changed from normal python image to slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.12-slim
 
 WORKDIR /hermes
 


### PR DESCRIPTION
Previously, the base image for the Hermes Docker image was `python:3.12`, which with all the required packages and dependencies, has a total weight of `1.22 GB`.

This change uses `python:3.12-slim` as the base image, which yields a total weight of just `352 MB`.

The slim Hermes version is just 28% of the size of the original version.

Sizes on local Docker repository
![sizes comparison](https://github.com/DarthTigerson/Hermes/assets/33274873/71e73d9d-2bdf-4b5e-ae6d-d4539ed130aa)


Compressed sizes on Dockerhub
![repository sizes](https://github.com/DarthTigerson/Hermes/assets/33274873/b05994a7-9f46-44b7-9e3e-85f78e2ff6e8)

