### PR TITLE
Run Hermes on production mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ You can install the [project locally](#local-installation), and run it as you se
 4. Give executable permissions to the launcher script: `chmod +x run.sh`
 5. Run the application: `./run.sh`
 
+## Run on production mode (with HTTPS)
+
+To run this over HTTPS, you will need your cert files.
+You can read more about that [here](https://letsencrypt.org/).
+
+1. Clone the repository: `git clone https://github.com/DarthTigerson/Hermes.git`
+2. Install the dependencies: `pip install -r requirements.txt`
+3. Create a `.env` file and set the environment variables (see `.env.example` for an example)
+4. Give executable permissions to the launcher script: `chmod +x run.sh`
+5. Execute the `run.sh` script with the following parameters: `run.sh <KEYFILE_PATH> <CERTFILE_PATH>`
+
+This way, Hermes will be running, available to your network, on port 443, with HTTPS.
+
 ## Build Docker image
 
 It is possible to build your own docker image from the `Dockerfile` in this repository.  

--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,20 @@
 #!/bin/bash
 
+# If database is not set, start it
 if [ ! -e db/hermes.db ]
 then
   mkdir db
   python startup.py --overwrite
 fi
 
-uvicorn main:app --host 0.0.0.0 --reload
+# If no params were given, run on dev mode
+if [ $# -eq 0 ]
+then
+  uvicorn main:app --host 0.0.0.0 --reload
+fi
+
+# If two params were given, run in production secure mode
+if [ $# -eq 2 ]
+then
+  uvicorn main:app --host 0.0.0.0 --port 443 --ssl-keyfile="$1"  --ssl-certfile="$2"
+fi


### PR DESCRIPTION
With these changes, people can run Hermes on production mode, with HTTPS.

Changes were made to the launcher script. Now it accepts two optional parameters for the cert files to run over HTTPS.

Instructions on how to run it on production mode were added to the README file.